### PR TITLE
Stop the player from interacting with more than 1 stuff at the same time

### DIFF
--- a/characters/player/player.tscn
+++ b/characters/player/player.tscn
@@ -270,7 +270,13 @@ position = Vector2(0.0360003, 4.68307)
 scale = Vector2(1.14518, 1.0892)
 polygon = PackedVector2Array(-3.84, 6.4, 3.84, 6.4, 3.84, -3.84, -3.84, -3.84)
 
-[node name="Timer" type="Timer" parent="."]
+[node name="InmunityCooldown" type="Timer" parent="."]
 wait_time = 1.5
 
-[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]
+[node name="UseCooldown" type="Timer" parent="."]
+wait_time = 1.5
+
+[connection signal="timeout" from="InmunityCooldown" to="." method="_on_inmunity_cooldown_timeout"]
+[connection signal="timeout" from="InmunityCooldown" to="." method="_on_timer_timeout"]
+[connection signal="timeout" from="UseCooldown" to="." method="_on_timer_timeout"]
+[connection signal="timeout" from="UseCooldown" to="." method="_on_use_cooldown_timeout"]

--- a/collectables/collectable.gd
+++ b/collectables/collectable.gd
@@ -19,7 +19,10 @@ func _process(delta: float) -> void:
 	pass
 
 func collect() -> InventoryItem:
-	print('collect called!!')
+	print('[Collectable] collect called!!')
+	if !player_in_area:
+		print('[Collectable] collect called but player no in area, returning...')
+		return
 	if animations != null: 
 		animations.play(animation_name)
 		await animations.animation_finished
@@ -44,9 +47,11 @@ func facing_down():
 	
 func _on_collectable_area_body_entered(body: Node2D) -> void:
 	if body is Player:
+		print('[Collectable] player in area')
 		player_in_area = true
 
 
 func _on_collectable_area_body_exited(body: Node2D) -> void:
 	if body is Player:
+		print('[Collectable] player left area')
 		player_in_area = false

--- a/collectables/collectable.tscn
+++ b/collectables/collectable.tscn
@@ -2,21 +2,23 @@
 
 [ext_resource type="Script" path="res://collectables/collectable.gd" id="1_lnhni"]
 [ext_resource type="Resource" uid="uid://ca6ofjq7o6pq0" path="res://inventory/items/coal_item.tres" id="2_7yq5t"]
-[ext_resource type="Texture2D" uid="uid://djlvewue6t3v0" path="res://assets/minerals/coal right.png" id="3_58vk8"]
+[ext_resource type="Texture2D" uid="uid://u7lsfir3cl3j" path="res://assets/minerals/coal left.png" id="3_je4vj"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_m0gom"]
-resource_local_to_scene = true
-size = Vector2(13, 20)
+[sub_resource type="CircleShape2D" id="CircleShape2D_yu6xx"]
+radius = 18.0
 
 [node name="Collectable" type="Node2D"]
 script = ExtResource("1_lnhni")
 collectableAsItem = ExtResource("2_7yq5t")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-texture = ExtResource("3_58vk8")
+texture = ExtResource("3_je4vj")
 
 [node name="CollectableArea" type="Area2D" parent="."]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="CollectableArea"]
-position = Vector2(26, -7)
-shape = SubResource("RectangleShape2D_m0gom")
+[node name="ColShape" type="CollisionShape2D" parent="CollectableArea"]
+position = Vector2(16, -8)
+shape = SubResource("CircleShape2D_yu6xx")
+
+[connection signal="body_entered" from="CollectableArea" to="." method="_on_collectable_area_body_entered"]
+[connection signal="body_exited" from="CollectableArea" to="." method="_on_collectable_area_body_exited"]

--- a/collectables/minerals/autoloader.gd
+++ b/collectables/minerals/autoloader.gd
@@ -98,6 +98,7 @@ func spawn_mineral_at_pos(coords: Vector2i, valid_pos: int):
 	var mineral_instance: Node = preload("res://collectables/minerals/mineral.tscn").instantiate()
 	mineral_instance.add_to_group("minerals", true)
 	mineral_instance.mineral_data = minerals_data_dict[mineral_name][valid_pos]
+	mineral_instance.use_collision_shape_from_direction(valid_pos)
 	# print('mineral data: ', mineral_instance.mineral_data.resource_name)
 	collectables_tilemap.spawn_scene_at_tile(coords, mineral_instance)
 	return

--- a/collectables/minerals/mineral.gd
+++ b/collectables/minerals/mineral.gd
@@ -1,10 +1,11 @@
-extends Node2D
-
-# Generic collectable, use it if it fulfills your needs
-# Or create your own .gd if you need to extend it (more variables)
-class_name Mineral
+class_name Mineral extends Collectable
 
 @export var mineral_data: MineralData
+
+const collision_south_position = Vector2(0,8)
+const collision_north_position = Vector2(-8,-16)
+const collision_east_position = Vector2(16,-8)
+const collision_west_position = Vector2(-16,-8)
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -15,6 +16,20 @@ func _process(delta: float) -> void:
 	pass
 
 func collect() -> InventoryItem:
-	print('mineral collect called!')
+	print('[Mineral] collect called!!')
+	if !player_in_area:
+		print('[Mineral] collect called but player no in area, returning...')
+		return
+
 	queue_free()
 	return mineral_data.collectableAsItem
+
+func use_collision_shape_from_direction(direction: int) -> void:
+	if direction == 0: # S
+		$CollectableArea/ColShape.position = collision_south_position
+	elif direction == 1: # E
+		$CollectableArea/ColShape.position = collision_east_position
+	elif direction == 2: # N
+		$CollectableArea/ColShape.position = collision_north_position
+	elif direction == 3: # W
+		$CollectableArea/ColShape.position = collision_west_position

--- a/collectables/minerals/mineral.tscn
+++ b/collectables/minerals/mineral.tscn
@@ -2,14 +2,18 @@
 
 [ext_resource type="PackedScene" uid="uid://bv7h1ae33nhjo" path="res://collectables/collectable.tscn" id="1_s673v"]
 [ext_resource type="Script" path="res://collectables/minerals/mineral.gd" id="2_eg51r"]
+[ext_resource type="Texture2D" uid="uid://7qct1fmoee62" path="res://assets/minerals/coal_top.png" id="3_gu5pp"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_1o44y"]
-resource_local_to_scene = true
-size = Vector2(13, 20)
-
-[node name="Coal" instance=ExtResource("1_s673v")]
+[node name="Mineral" instance=ExtResource("1_s673v")]
 script = ExtResource("2_eg51r")
 mineral_data = null
 
-[node name="CollisionShape2D" parent="CollectableArea" index="0"]
-shape = SubResource("RectangleShape2D_1o44y")
+[node name="Sprite2D" parent="." index="0"]
+texture = ExtResource("3_gu5pp")
+
+[node name="CollectableArea" parent="." index="1"]
+collision_layer = 8
+collision_mask = 2
+
+[node name="ColShape" parent="CollectableArea" index="0"]
+position = Vector2(-2, -16)

--- a/interaction_manager.gd
+++ b/interaction_manager.gd
@@ -40,9 +40,15 @@ func set_inventory(i):
 
 func buy_item(shopItem: ShopItem):
 	# TODO: Avoid negative money
+	if player.is_interacting:
+		print('[InteractionManager] Stopped buy because player is interacting with something else')
+		return false
+	player.is_interacting = true
 	print('BUYING ITEMMM: ', shopItem.inventoryItem.name)
 	PlayerManager.gold -= shopItem.price
 	inventoryGUI.inventory.insert(shopItem.inventoryItem)
+	player.use_cooldown.start()
+	return true
 
 func consume_item(inv_item: InventoryItem):
 	print('[InteractionManager] CONSUMING!!')

--- a/muki.gd
+++ b/muki.gd
@@ -41,7 +41,8 @@ func _process(delta: float) -> void:
 func _input(event: InputEvent) -> void:
 	if $ShopUI.is_visible() and event.is_action_pressed("use"):
 		print('[Muki] buying item!!! ', selected_shop_item.inventoryItem.name)
-		InteractionManager.buy_item(selected_shop_item)
+		var success = InteractionManager.buy_item(selected_shop_item)
+		if !success: return
 		delete_related_item(selected_shop_item)
 		$ShopUI.hide()
 		selected_shop_item = null

--- a/screens/world.gd
+++ b/screens/world.gd
@@ -51,7 +51,13 @@ func _on_inventory_opened() -> void:
 	# get_tree().paused = true
 	pass
 
-func _on_travel_area_body_entered(_body: Node2D) -> void:
+func _on_health_bar_player_died() -> void:
+	$SceneTransitioner.trigger_lose()
+
+func _on_food_bar_player_starved() -> void:
+	$SceneTransitioner.trigger_lose()
+
+func _on_ladder_area_body_entered(body: Node2D) -> void:
 	floor += 1
 	get_tree().paused = true  # Pauses everything
 	if floor == 3:
@@ -63,13 +69,3 @@ func _on_travel_area_body_entered(_body: Node2D) -> void:
 	$TileMap/walls.restart_maze()
 	await $SceneTransitioner.trigger_unveil_screen()
 	get_tree().paused = false 
-
-func _on_health_bar_player_died() -> void:
-	$SceneTransitioner.trigger_lose()
-
-func _on_food_bar_player_starved() -> void:
-	$SceneTransitioner.trigger_lose()
-
-
-func _on_ladder_area_body_entered(body: Node2D) -> void:
-	pass # Replace with function body.

--- a/screens/world.tscn
+++ b/screens/world.tscn
@@ -528,9 +528,9 @@ script = ExtResource("7_egp0i")
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = 200.0
+offset_left = 107.0
 offset_top = 124.0
-offset_right = 277.0
+offset_right = 184.0
 offset_bottom = 173.0
 grow_horizontal = 0
 scale = Vector2(0.5, 0.5)
@@ -595,7 +595,7 @@ editor_draw_screen = false
 script = ExtResource("15_ltbuh")
 tileMapLayer = NodePath("../../TileMap/walls")
 
-[node name="TravelArea" parent="." instance=ExtResource("16_26qvb")]
+[node name="LadderArea" parent="." instance=ExtResource("16_26qvb")]
 
 [node name="Muki" parent="." instance=ExtResource("17_1bifo")]
 visibility_layer = 3
@@ -628,6 +628,6 @@ color = Color(0, 0, 0, 1)
 [connection signal="opened" from="CanvasLayer/InventoryGUI" to="." method="_on_inventory_opened"]
 [connection signal="player_died" from="CanvasLayer/HealthBar" to="." method="_on_health_bar_player_died"]
 [connection signal="player_starved" from="CanvasLayer/FoodBar" to="." method="_on_food_bar_player_starved"]
-[connection signal="stair_decided" from="TileMap/walls" to="TravelArea" method="_on_walls_stair_decided"]
+[connection signal="stair_decided" from="TileMap/walls" to="LadderArea" method="_on_walls_stair_decided"]
 [connection signal="mouse_entered" from="Player" to="Player" method="_on_mouse_entered"]
-[connection signal="body_entered" from="TravelArea" to="." method="_on_travel_area_body_entered"]
+[connection signal="body_entered" from="LadderArea" to="." method="_on_ladder_area_body_entered"]

--- a/tilemaps/collectables_tilemap.gd
+++ b/tilemaps/collectables_tilemap.gd
@@ -30,6 +30,12 @@ func collectable_at_tile(tileset_cords: Vector2i) -> Node2D:
 
 	return null
 
+func collectable_at_world_pos(world_cords: Vector2i):
+	var tileset_cords = self.local_to_map(world_cords)
+	print('cords mapped to local ', world_cords, '  in tileset : ', tileset_cords)
+	
+	return collectable_at_tile(tileset_cords)
+	
 func collect_tile(cords: Vector2i):
 	var tileset_cords = self.local_to_map(cords)
 	print('cords mapped to local ', cords, '  in tileset : ', tileset_cords)


### PR DESCRIPTION
 When there is a chest and a mineral, if you interact it collects both.


Same in the muki shop if there is a mineral, it buys the item and collects the mineral.


Now it does only 1 thing at the same time. I added a UseCooldown with 1.5s delay which after the timeout, puts `is_interacting = false` to not allow the player to interact with other stuff during that time (the player was already pausing because of the animation, but its not enough)

